### PR TITLE
Corrected :h4:

### DIFF
--- a/markdown-shortcuts/0.1.0/package.yml
+++ b/markdown-shortcuts/0.1.0/package.yml
@@ -23,7 +23,7 @@ matches:
     replace: "###"
 
   - trigger: ":h4:"
-    replace: "###"
+    replace: "####"
 
   - trigger: ":h5:"
     replace: "#####"


### PR DESCRIPTION
:h4: shortcut set to replace with "### ", the same as :h3:. Edited so that :h4: set to replace with "#### " instead.